### PR TITLE
feat: adopt template conf.py and wire plausible_domain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ from project_info import (
     eyebrow_text,
     github_repository,
     languages,
+    plausible_domain,
     redoc,
 )
 
@@ -68,6 +69,7 @@ html_theme_options = {  # See https://iati-sphinx-theme.readthedocs-hosted.com/e
     "header_title_text": _(project),
     "header_eyebrow_text": _(eyebrow_text),
     "languages": languages,
+    "plausible_domain": plausible_domain,
     "project_title": _(project_title),
     "show_download_links": True,
     "tool_nav_items": tool_nav_items,

--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -21,7 +21,7 @@ github_repository = "https://github.com/IATI/iati-d-portal-docs"
 
 # Plausible analytics domain, derived from tool_url so docs are tracked
 # under the tool's site. Set to None to disable.
-plausible_domain = urlparse(tool_url).hostname if tool_url else None
+plausible_domain = "d-portal.org"
 
 # Supported languages for the documentation
 languages = ["en", "fr", "es"]

--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -2,6 +2,8 @@
 # This file contains settings that vary per repository.
 # The main conf.py imports these values and can be synced across all repos.
 
+from urllib.parse import urlparse
+
 # Project name (used for titles, headers, and Sphinx internals)
 project = "d-portal"
 
@@ -16,6 +18,10 @@ eyebrow_text = "IATI Tools: Documentation"
 
 # GitHub repository URL (used by the theme for the "Source code at GitHub" footer link)
 github_repository = "https://github.com/IATI/iati-d-portal-docs"
+
+# Plausible analytics domain, derived from tool_url so docs are tracked
+# under the tool's site. Set to None to disable.
+plausible_domain = urlparse(tool_url).hostname if tool_url else None
 
 # Supported languages for the documentation
 languages = ["en", "fr", "es"]


### PR DESCRIPTION
Finish the interrupted conf.py migration: add plausible_domain (derived from tool_url) to project_info.py and adopt the template conf.py verbatim, so conf.py becomes syncable. Turns on Plausible for repos that set a tool_url.